### PR TITLE
Fix /sidekiq_queues endpoint output

### DIFF
--- a/lib/sidekiq-monitoring.rb
+++ b/lib/sidekiq-monitoring.rb
@@ -28,7 +28,11 @@ class SidekiqMonitoring < Sinatra::Base
 
   get '/sidekiq_queues' do
     content_type :json
-    JSON.generate SidekiqMonitoring::Global.new(self.class.queue_size_thresholds, self.class.latency_thresholds, self.class.elapsed_thresholds)
+    JSON.generate(
+      SidekiqMonitoring::Global
+        .new(self.class.queue_size_thresholds, self.class.latency_thresholds, self.class.elapsed_thresholds)
+        .as_json
+    )
   end
 
   module StatusMixin

--- a/spec/sidekiq-monitoring_spec.rb
+++ b/spec/sidekiq-monitoring_spec.rb
@@ -247,6 +247,8 @@ describe SidekiqMonitoring do
       get '/sidekiq_queues'
       expect(last_response).to be_ok
       expect(last_response.content_type).to eq('application/json')
+      body = JSON.parse(last_response.body)
+      expect(body).to include('global_status', 'queues', 'workers')
     end
 
   end


### PR DESCRIPTION
Before:
```
"#<SidekiqMonitoring::Global:0x00007f3e605552f8>"
```
After:
```
{"global_status":"CRITICAL","queues":[...],"workers":[]}
```